### PR TITLE
feat: adapt flash light in dark scenes 🎃🛠

### DIFF
--- a/CardScanner/Classes/CardScanner.swift
+++ b/CardScanner/Classes/CardScanner.swift
@@ -86,6 +86,8 @@ public class CardScanner: UIViewController {
         let buttomItem = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(scanCompleted))
         buttomItem.tintColor = .white
         navigationItem.leftBarButtonItem = buttomItem
+        
+        self.setupTorch()
     }
 
     override public func viewDidLayoutSubviews() {
@@ -248,6 +250,7 @@ public class CardScanner: UIViewController {
 
     private func stop() {
         captureSession.stopRunning()
+        self.turnOffFlashlight()
     }
 
     // MARK: - Payment detection
@@ -346,6 +349,34 @@ public class CardScanner: UIViewController {
                 creditCardName = line
                 continue
             }
+        }
+    }
+    
+    func setupTorch() {
+            guard let device = device, device.hasTorch else {return}
+
+            do {
+                try device.lockForConfiguration()
+                
+                // Set the torch mode to auto
+                if device.isTorchModeSupported(.auto) {
+                    device.torchMode = .auto
+                }
+                device.unlockForConfiguration()
+            } catch {
+                // Handle any errors
+            }
+    }
+    
+    func turnOffFlashlight() {
+        guard let device = device, device.hasTorch else {return}
+        
+        do {
+            try device.lockForConfiguration()
+            device.torchMode = .off
+            device.unlockForConfiguration()
+        } catch {
+            // Handle any errors
         }
     }
 


### PR DESCRIPTION
- Description
In the dark scenes, the camera can't capture the credit card pieces of information in the right way because there is no light.
I make it possible by turning on the torch only if it's in the dark (Auto).

https://github.com/narlei/CardScanner/assets/94869017/835d6c31-1b7f-4b83-90a0-29f0a3f89ac3

